### PR TITLE
fix: export IEditorDocumentModelService to the umd bundle

### DIFF
--- a/packages/core/src/api/exports.ts
+++ b/packages/core/src/api/exports.ts
@@ -2,6 +2,8 @@ import { REPORT_NAME, BrowserFSFileType, HOME_ROOT, WORKSPACE_ROOT } from '@code
 
 export { Uri, Emitter } from '@opensumi/ide-core-common';
 
+export { IEditorDocumentModelService } from '@codeblitzjs/ide-core/lib/modules/opensumi__ide-editor';
+
 export { getDefaultLayoutConfig } from '../core/layout';
 
 export { REPORT_NAME, BrowserFSFileType, HOME_ROOT, WORKSPACE_ROOT };


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

export to the umd bundle


IEditorDocumentModelService is not reachable via the umd bundle.

### ChangeLog


export `IEditorDocumentModelService` to the umd bundle
