### PR TITLE
fix: should not export from codeblitz modules

### DIFF
--- a/packages/core/src/api/exports.ts
+++ b/packages/core/src/api/exports.ts
@@ -1,8 +1,13 @@
-import { REPORT_NAME, BrowserFSFileType, HOME_ROOT, WORKSPACE_ROOT } from '@codeblitzjs/ide-sumi-core';
+import {
+  REPORT_NAME,
+  BrowserFSFileType,
+  HOME_ROOT,
+  WORKSPACE_ROOT,
+} from '@codeblitzjs/ide-sumi-core';
 
 export { Uri, Emitter } from '@opensumi/ide-core-common';
 
-export { IEditorDocumentModelService } from '@codeblitzjs/ide-core/lib/modules/opensumi__ide-editor';
+export { IEditorDocumentModelService } from '@opensumi/ide-editor/lib/browser/doc-model/types';
 
 export { getDefaultLayoutConfig } from '../core/layout';
 

--- a/packages/core/src/api/exports.ts
+++ b/packages/core/src/api/exports.ts
@@ -7,8 +7,6 @@ import {
 
 export { Uri, Emitter } from '@opensumi/ide-core-common';
 
-export { IEditorDocumentModelService } from '@opensumi/ide-editor/lib/browser/doc-model/types';
-
 export { getDefaultLayoutConfig } from '../core/layout';
 
 export { REPORT_NAME, BrowserFSFileType, HOME_ROOT, WORKSPACE_ROOT };


### PR DESCRIPTION
### Types


- [x] 🐛 Bug Fixes


### Background or solution

this pr export something from a non-existent file
- https://github.com/opensumi/codeblitz/pull/76

### ChangeLog

should not export from codeblitz modules