### PR TITLE
fix: create new channel when needed

### DIFF
--- a/packages/core/src/api/renderDiffViewer.tsx
+++ b/packages/core/src/api/renderDiffViewer.tsx
@@ -14,6 +14,13 @@ import { BoxPanel, SplitPanel } from '../editor';
 import { Injector } from '../modules/opensumi__common-di';
 import { AppRenderer, IAppRendererProps } from './renderApp';
 
+export {
+  IDiffViewerHandle,
+  IDiffViewerProps,
+  IDiffViewerTab,
+  IExtendPartialEditEvent,
+} from '../core/diff-viewer/common';
+
 export const defaultLayoutConfig = {
   [SlotLocation.action]: {
     modules: [''],

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,5 +2,6 @@ export * from './api/createApp';
 export * from './api/exports';
 export * from './api/register';
 export * from './api/renderApp';
+export * from './api/renderDiffViewer';
 export * from './api/require';
 export * from './api/types';

--- a/packages/sumi-core/src/client/index.ts
+++ b/packages/sumi-core/src/client/index.ts
@@ -36,6 +36,7 @@ import { SearchContribution } from './search/index.contribution';
 import { WebConnectionHelper } from '@opensumi/ide-core-browser/lib/application/runtime';
 import { IExtensionStorageService } from '@opensumi/ide-extension-storage';
 import { getThemeTypeByPreferenceThemeId } from '../common/theme';
+import { createChannel, InMemoryMessageChannel } from '../connection';
 import { CodeBlitzAINativeContribution } from './ai-native';
 import { injectAINativePreferences } from './ai-native/preferences';
 import { ExtensionStorageServiceOverride } from './override/extensionStorageService';
@@ -135,6 +136,11 @@ export class ClientApp extends BasicClientApp {
   constructor(opts: IAppOpts) {
     super(opts);
     this.modules = opts.modules;
+
+    this.injector.addProviders({
+      token: InMemoryMessageChannel,
+      useValue: createChannel(),
+    });
     this.initServer(opts);
     this.initMonacoProxy();
   }

--- a/packages/sumi-core/src/client/override/webConnectionHelper.ts
+++ b/packages/sumi-core/src/client/override/webConnectionHelper.ts
@@ -1,19 +1,23 @@
-import { Injectable } from '@opensumi/di';
+import { Autowired, Injectable } from '@opensumi/di';
 import { IRuntimeSocketConnection, WSChannel } from '@opensumi/ide-connection';
 import { WSChannelHandler } from '@opensumi/ide-connection/lib/browser/ws-channel-handler';
 import { RawMessageIO } from '@opensumi/ide-connection/lib/common/rpc/message-io';
 import { rawSerializer } from '@opensumi/ide-connection/lib/common/serializer/raw';
 import { createConnectionService, getDebugLogger, ModuleConstructor } from '@opensumi/ide-core-browser';
 import { BaseConnectionHelper } from '@opensumi/ide-core-browser/lib/application/runtime/base-socket';
-import { ClientPort, CodeBlitzConnection } from '../../connection';
+import { CodeBlitzConnection, InMemoryMessageChannel } from '../../connection';
 
 @Injectable({ multiple: true })
 export class CodeBlitzConnectionHelper extends BaseConnectionHelper {
+  @Autowired(InMemoryMessageChannel)
+  private channel: InMemoryMessageChannel;
+
   getDefaultClientId() {
     return 'codeblitz';
   }
+
   createConnection(): IRuntimeSocketConnection {
-    return new CodeBlitzConnection(ClientPort);
+    return new CodeBlitzConnection(this.channel.port1);
   }
 
   createRPCServiceChannel(modules: ModuleConstructor[]): Promise<WSChannel> {

--- a/packages/sumi-core/src/connection/index.ts
+++ b/packages/sumi-core/src/connection/index.ts
@@ -11,7 +11,13 @@ export interface Port {
   call(...args: any): any;
 }
 
-const createChannel: () => { port1: Port; port2: Port } = () => {
+export const InMemoryMessageChannel = Symbol('InMemoryMessageChannel');
+export interface InMemoryMessageChannel {
+  port1: Port;
+  port2: Port;
+}
+
+export const createChannel: () => InMemoryMessageChannel = () => {
   type InnerPort = {
     callback(...args: any[]): any;
     listen(cb: (...args: any[]) => any): void;
@@ -39,10 +45,6 @@ const createChannel: () => { port1: Port; port2: Port } = () => {
   port2._entangledPort = port1;
   return { port1, port2 };
 };
-
-const { port1, port2 } = createChannel();
-
-export { port1 as ClientPort, port2 as ServerPort };
 
 export abstract class RPCService {
   client?: any;

--- a/packages/sumi-core/src/server/core/app.ts
+++ b/packages/sumi-core/src/server/core/app.ts
@@ -20,7 +20,7 @@ import {
   SupportLogNamespace,
 } from '@opensumi/ide-core-common';
 import * as path from 'path';
-import { CodeBlitzConnection, ServerPort } from '../../connection';
+import { CodeBlitzConnection, InMemoryMessageChannel, Port } from '../../connection';
 import { ILogServiceManager } from './base';
 import { INodeLogger, NodeLogger } from './node-logger';
 
@@ -220,7 +220,9 @@ export class ServerApp implements IServerApp {
     await this.launch();
     await this.initializeContribution();
     const handler = new CodeblitzCommonChannelHandler('codeblitz-server');
-    handler.receiveConnection(new CodeBlitzConnection(ServerPort));
+
+    const channel = this.injector.get(InMemoryMessageChannel) as InMemoryMessageChannel;
+    handler.receiveConnection(new CodeBlitzConnection(channel.port2));
 
     commonChannelPathHandler.register(RPCServiceChannelPath, {
       handler: (channel: WSChannel, clientId: string) => {


### PR DESCRIPTION
### Types


- [x] 🐛 Bug Fixes


### Background or solution

原来 Codeblitz 只默认创建了一对 Port，会导致创建多个 AppRenderer 时，还是复用这一个 Port，会导致功能错乱等。

### ChangeLog

create channel when needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新特性**
	- 引入了`InMemoryMessageChannel`，改善了应用内的消息处理能力。
	- 通过依赖注入的方式，增强了`CodeBlitzConnectionHelper`和`ServerApp`类的连接管理灵活性。
	- 导出了`renderDiffViewer`函数，提升了模块的功能性。

- **文档**
	- 新增了与差异查看器相关的类型，增强了模块的类型安全性和可读性。

- **修复**
	- 重新设计了连接建立逻辑，改进了性能与测试能力。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->