### PR TITLE
fix: dispose plugin service will cause crash

### DIFF
--- a/packages/core/src/api/createApp.tsx
+++ b/packages/core/src/api/createApp.tsx
@@ -7,6 +7,7 @@ import {
   makeWorkspaceDir,
   RuntimeConfig,
   STORAGE_DIR,
+  tryCatchPromise,
 } from '@codeblitzjs/ide-sumi-core';
 import {
   FILES_DEFAULTS,
@@ -127,7 +128,7 @@ export function createApp({ appConfig, runtimeConfig }: IConfig): IAppInstance {
     destroyed = true;
     disposeMode();
     disposableCollection.forEach((d) => d(app.injector));
-    app.injector.disposeAll();
+    tryCatchPromise(() => app.injector.disposeAll());
   };
 
   return app;

--- a/packages/core/src/api/createEditor.tsx
+++ b/packages/core/src/api/createEditor.tsx
@@ -7,6 +7,7 @@ import {
   makeWorkspaceDir,
   RuntimeConfig,
   STORAGE_DIR,
+  tryCatchPromise,
 } from '@codeblitzjs/ide-sumi-core';
 import { Injector } from '@opensumi/di';
 import { FILES_DEFAULTS, IAppRenderer, IReporter, SlotLocation, SlotRenderer } from '@opensumi/ide-core-browser';
@@ -100,7 +101,7 @@ export function createEditor({ appConfig, runtimeConfig }: IConfig): IAppInstanc
     destroyed = true;
     disposeMode();
     disposableCollection.forEach((d) => d(app.injector));
-    app.injector.disposeAll();
+    tryCatchPromise(() => app.injector.disposeAll());
   };
 
   return app;

--- a/packages/plugin/src/plugin.contribution.ts
+++ b/packages/plugin/src/plugin.contribution.ts
@@ -15,7 +15,7 @@ export class PluginContribution implements ClientAppContribution {
   }
 
   dispose() {
-    // dispose 阶段不保证顺序，
+    // dispose 阶段不保证顺序，如果 IPluginService 比 PluginContribution 先 dispose，会导致此时 `this.pluginService` 为空
     if (this.pluginService) {
       this.pluginService.deactivate();
     }

--- a/packages/plugin/src/plugin.contribution.ts
+++ b/packages/plugin/src/plugin.contribution.ts
@@ -15,6 +15,9 @@ export class PluginContribution implements ClientAppContribution {
   }
 
   dispose() {
-    this.pluginService.deactivate();
+    // dispose 阶段不保证顺序，
+    if (this.pluginService) {
+      this.pluginService.deactivate();
+    }
   }
 }

--- a/packages/plugin/src/plugin.service.ts
+++ b/packages/plugin/src/plugin.service.ts
@@ -75,4 +75,8 @@ export class PluginService {
       this.pluginActivator.set(plugin.PLUGIN_ID, { subscriptions: context.subscriptions });
     }
   }
+
+  dispose() {
+    this.deactivate();
+  }
 }

--- a/packages/sumi-core/src/client/override/monacoOverride/contextKeyService.ts
+++ b/packages/sumi-core/src/client/override/monacoOverride/contextKeyService.ts
@@ -200,6 +200,5 @@ export class MonacoContextKeyServiceOverride extends BaseContextKeyService imple
 
   dispose(): void {
     // context 不需要dispose
-    // super.dispose();
   }
 }

--- a/packages/sumi-core/src/common/util.ts
+++ b/packages/sumi-core/src/common/util.ts
@@ -1,7 +1,7 @@
 import { IExtensionIdentity, IExtensionMode } from '@codeblitzjs/ide-common';
 import { ConstructorOf, Provider } from '@opensumi/di';
 import { BrowserModule } from '@opensumi/ide-core-browser';
-import { BackService } from '@opensumi/ide-core-common';
+import { BackService, MaybePromise } from '@opensumi/ide-core-common';
 import * as paths from 'path';
 import { EXT_SCHEME, OSSBucket, WORKSPACE_ROOT } from './constant';
 
@@ -100,3 +100,13 @@ export const extendModule = ({
     }
   };
 };
+
+export const tryCatchPromise = (fn: () => MaybePromise<void>): Promise<void> => {
+  const run = async () => {
+    return await fn();
+  }
+
+  return run().catch((e) => {
+    console.error("dispose injector error", e);
+  });
+}

--- a/packages/sumi-core/src/server/core/app.ts
+++ b/packages/sumi-core/src/server/core/app.ts
@@ -27,7 +27,7 @@ import { INodeLogger, NodeLogger } from './node-logger';
 import { HOME_ROOT, IServerApp } from '../../common';
 import { STORAGE_DIR, WORKSPACE_ROOT } from '../../common/constant';
 import { RootFS, RuntimeConfig } from '../../common/types';
-import { isBackServicesInServer } from '../../common/util';
+import { isBackServicesInServer, tryCatchPromise } from '../../common/util';
 import { fsExtra as fse } from '../node';
 import { initializeHomeFileSystem, initializeRootFileSystem, unmountRootFS } from './filesystem';
 
@@ -320,7 +320,8 @@ function handleClientChannel(
 
   channel.onceClose(() => {
     remove.dispose();
-    serviceChildInjector.disposeAll();
+
+    tryCatchPromise(() => serviceChildInjector.disposeAll());
 
     logger.log(`Remove RPC connection ${clientId}`);
   });

--- a/packages/sumi-core/src/server/core/app.ts
+++ b/packages/sumi-core/src/server/core/app.ts
@@ -283,7 +283,7 @@ export function bindModuleBackService(
         serviceCenter.loadProtocol(service.protocol);
       }
 
-      logger.log('back service', serviceToken);
+      logger.log('bind back service', serviceToken);
       const serviceInstance = childInjector.get(serviceToken);
       const proxyService = createRPCService(servicePath, serviceInstance);
       if (!serviceInstance.client) {
@@ -319,10 +319,9 @@ function handleClientChannel(
   );
 
   channel.onceClose(() => {
-    remove.dispose();
-
-    tryCatchPromise(() => serviceChildInjector.disposeAll());
-
     logger.log(`Remove RPC connection ${clientId}`);
+
+    remove.dispose();
+    tryCatchPromise(() => serviceChildInjector.disposeAll());
   });
 }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

![CleanShot 2024-08-01 at 14 30 08@2x](https://github.com/user-attachments/assets/e711c76f-c984-419f-9059-edadead53006)

卸载组件的时候会报错

### ChangeLog

fix some crashes about dispose


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 引入了 `tryCatchPromise` 函数，以增强异步操作的错误处理。
	- 在 `PluginService` 类中添加了 `dispose` 方法，以改善插件的生命周期管理。
  
- **改进**
	- 更新了多个模块的清理逻辑，确保在调用相关方法前进行必要的检查，从而提高了应用的稳定性。

- **错误修复**
	- 改善了错误处理和日志记录功能，降低了潜在崩溃的风险。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->