### PR TITLE
fix: hide bottom tab panel if no container

### DIFF
--- a/packages/core/src/core/diff-viewer/internal/base.ts
+++ b/packages/core/src/core/diff-viewer/internal/base.ts
@@ -45,7 +45,7 @@ export class DiffViewerContribution implements CommandContribution, ClientAppCon
   protected inlineDiffHandler: InlineDiffHandler;
 
   @Autowired(IEditorDocumentModelService)
-  private readonly editorCollectionService: IEditorDocumentModelService;
+  private readonly editorDocumentModelService: IEditorDocumentModelService;
 
   @Autowired(AppConfig)
   protected appConfig: AppConfig;
@@ -112,7 +112,7 @@ export class DiffViewerContribution implements CommandContribution, ClientAppCon
         return;
       }
 
-      const model = this.editorCollectionService.getModelReference(uri);
+      const model = this.editorDocumentModelService.getModelReference(uri);
       if (!model || !model.instance) {
         throw new Error('Failed to get model reference: ' + filePath);
       }

--- a/packages/core/src/core/layout.tsx
+++ b/packages/core/src/core/layout.tsx
@@ -1,16 +1,18 @@
 import { SlotLocation, SlotRenderer } from '@opensumi/ide-core-browser';
-import { BoxPanel, SplitPanel } from '@opensumi/ide-core-browser/lib/components';
+import { BoxPanel, getStorageValue, SplitPanel } from '@opensumi/ide-core-browser/lib/components';
 import * as React from 'react';
 
 export function LayoutComponent(): React.ReactElement {
+  const { layout } = getStorageValue();
+
   return (
     <BoxPanel direction='top-to-bottom'>
       <SlotRenderer slot='top' />
       <SplitPanel overflow='hidden' id='main-horizontal' flex={1}>
-        <SlotRenderer slot='left' defaultSize={310} minResize={204} minSize={49} />
+          <SlotRenderer slot='left' defaultSize={layout.left?.currentId ? layout.left?.size || 310 : 49}  minResize={204} minSize={49} />
         <SplitPanel id='main-vertical' minResize={300} flexGrow={1} direction='top-to-bottom'>
           <SlotRenderer flex={2} flexGrow={1} minResize={200} slot='main' />
-          <SlotRenderer flex={1} minResize={160} slot='bottom' />
+          <SlotRenderer flex={1} minResize={160} slot='bottom' defaultSize={layout.bottom?.currentId ? layout.bottom?.size : 24} />
         </SplitPanel>
       </SplitPanel>
       <SlotRenderer slot='statusBar' />

--- a/packages/startup/src/filesystem/index.tsx
+++ b/packages/startup/src/filesystem/index.tsx
@@ -31,7 +31,7 @@ const zipDataPromise = (async () => {
 })();
 
 const App = () => {
-  const [fsType, setFsType] = useState<string>('');
+  const [fsType, setFsType] = useState<string>('ZipFS');
 
   const filesystem = useMemo<
     NonNullable<IAppRendererProps['runtimeConfig']['workspace']>['filesystem'] | undefined


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

- https://github.com/opensumi/core/pull/3925

### ChangeLog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 改进布局管理，以支持用户特定的布局调整，确保设置在会话间保持一致。
	- 默认文件系统类型设置为“ZipFS”，优化组件初始化行为。

- **Bug修复**
	- 修正了`DiffViewerContribution`类中的变量命名，提高了代码的清晰度和一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->