### PR TITLE
fix: code service support configure fs

### DIFF
--- a/packages/code-service/src/code-service.contribution.ts
+++ b/packages/code-service/src/code-service.contribution.ts
@@ -4,6 +4,7 @@ import {
   CODE_ROOT,
   IDB_ROOT,
   IServerApp,
+  isPathMounted,
   LaunchContribution,
   RootFS,
   RuntimeConfig,
@@ -220,6 +221,10 @@ export class CodeContribution
       );
 
       this._unmount?.();
+
+      if (isPathMounted(rootFS, workspaceDir)) {
+        rootFS.umount(workspaceDir);
+      }
 
       rootFS.mount(workspaceDir, overlayFileSystem);
       // 将只读文件系统挂载到 /code 上

--- a/packages/startup/src/startup/index.tsx
+++ b/packages/startup/src/startup/index.tsx
@@ -187,7 +187,12 @@ const App = () => (
     }}
     runtimeConfig={{
       scmFileTree: true,
-      scenario: 'ALEX_TEST',
+      scenario: 'startup',
+      workspace: {
+        filesystem: {
+          fs: 'InMemory'
+        }
+      },
       aiNative: {
         enable: true,
         providerEditorInlineChat(): IEditorInlineChat[] {

--- a/packages/sumi-core/src/server/core/app.ts
+++ b/packages/sumi-core/src/server/core/app.ts
@@ -5,8 +5,8 @@ import { RawMessageIO } from '@opensumi/ide-connection/lib/common/rpc/message-io
 import { rawSerializer } from '@opensumi/ide-connection/lib/common/serializer/raw';
 import {
   BaseCommonChannelHandler,
-  RPCServiceChannelPath,
   CommonChannelPathHandler,
+  RPCServiceChannelPath,
 } from '@opensumi/ide-connection/lib/common/server-handler';
 import { AppConfig, BrowserModule } from '@opensumi/ide-core-browser';
 import {

--- a/packages/sumi-core/src/server/core/fs-launch.contribution.ts
+++ b/packages/sumi-core/src/server/core/fs-launch.contribution.ts
@@ -2,7 +2,7 @@ import { Autowired } from '@opensumi/di';
 import { ContributionProvider, Disposable, Domain, localize } from '@opensumi/ide-core-common';
 import { IMessageService } from '@opensumi/ide-overlay';
 import { AppConfig, IServerApp, RootFS, RuntimeConfig } from '../../common/types';
-import { BrowserFS } from '../node';
+import { BrowserFS, isPathMounted } from '../node';
 import { LaunchContribution } from './app';
 import { FileSystemContribution } from './base';
 
@@ -39,8 +39,7 @@ export class FileSystemConfigContribution extends Disposable implements FileSyst
     const fsConfig = this.runtimeConfig.workspace?.filesystem;
     if (!fsConfig) return;
     const { workspaceDir } = this.appConfig;
-    // @ts-ignore
-    if (rootFS && rootFS.mountList.includes(workspaceDir)) {
+    if (isPathMounted(rootFS, workspaceDir)) {
       return;
     }
     try {

--- a/packages/sumi-core/src/server/node/bfs/index.ts
+++ b/packages/sumi-core/src/server/node/bfs/index.ts
@@ -18,7 +18,7 @@ import MountableFileSystem, {
 } from '@codeblitzjs/ide-browserfs/lib/backend/MountableFileSystem';
 import OverlayFS, { deletionLogPath, OverlayFSOptions } from '@codeblitzjs/ide-browserfs/lib/backend/OverlayFS';
 import ZipFS, { ZipFSOptions } from '@codeblitzjs/ide-browserfs/lib/backend/ZipFS';
-import { WORKSPACE_IDB_NAME } from '../../../common';
+import { RootFS, WORKSPACE_IDB_NAME } from '../../../common';
 import { Editor, EditorOptions } from './Editor';
 import { FileIndexSystem, FileIndexSystemOptions } from './FileIndex';
 
@@ -179,3 +179,12 @@ type InstanceType<T> = T extends { Create(options: object, cb: BFSCallback<infer
   : any;
 
 export type FileSystemInstance<T extends SupportFileSystem> = InstanceType<(typeof Backends)[T]>;
+
+export function isPathMounted(fs: RootFS, path: string): boolean {
+  // @ts-ignore
+  if (fs && fs.mountList.includes(path)) {
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution


如果配置了 workspace.fs 配置，FileSystemConfigContribution 会挂载相应的 fs 到 workspaceDir。
如果同时启用了 CodeServiceModule, 它也会挂载 InMemoryFS 到 workspaceDir，就挂了。



### ChangeLog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 添加了一个新的功能 `isPathMounted`，用于检查特定路径是否已挂载，从而增强文件系统的操作能力。
	- 更新了应用程序的配置对象，允许更灵活的文件系统操作。

- **改进**
	- 在文件卸载操作中添加条件检查，以确保只在路径已挂载时进行卸载，提高了文件系统操作的稳健性。

- **样式**
	- 重新排序了导入语句，改善了代码的组织结构。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->