### PR TITLE
fix: update RuntimeConfig.workspace.filesystem to  non-required

### DIFF
--- a/packages/sumi-core/src/common/types.ts
+++ b/packages/sumi-core/src/common/types.ts
@@ -51,7 +51,7 @@ export interface RuntimeConfig {
     /**
      * 文件系统配置
      */
-    filesystem: FileSystemConfiguration;
+    filesystem?: FileSystemConfiguration;
     /**
      * 文档保存事件
      * @param data.filepath 文档相对工作空间路径


### PR DESCRIPTION
### Types
- [X] 🐛 Bug Fixes

### Background or solution


### ChangeLog
fix：更新 RuntimeConfig.workspace.filesystem为非必填类型

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 更新了 `RuntimeConfig` 接口，使得 `filesystem` 属性可选，增强了灵活性。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->