### PR TITLE
build: package react to the bundle file

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -83,7 +83,7 @@
     "@types/react-dom": "^18.2.0"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.2.0 || ^16.0.0",
+    "react-dom": "^18.2.0 || ^16.0.0"
   }
 }

--- a/packages/core/src/api/require.ts
+++ b/packages/core/src/api/require.ts
@@ -55,6 +55,8 @@ import * as buffer from 'buffer';
 import * as crypto from 'crypto';
 import * as os from 'os';
 import * as path from 'path';
+import * as React from 'react';
+import ReactDOM, * as ReactDom from 'react-dom/client';
 
 export function requireModule(module: '@opensumi/ide-addons'): typeof Addons;
 export function requireModule(module: '@opensumi/ide-comments'): typeof Comments;
@@ -109,6 +111,8 @@ export function requireModule(module: 'buffer'): typeof buffer;
 export function requireModule(module: 'process'): typeof process;
 export function requireModule(module: 'assert'): typeof assert;
 export function requireModule(module: 'path'): typeof path;
+export function requireModule(module: 'react'): typeof React;
+export function requireModule(module: 'react-dom/client'): typeof ReactDom;
 
 export function requireModule(module: string): any {
   switch (module) {
@@ -215,7 +219,10 @@ export function requireModule(module: string): any {
       return assert;
     case 'path':
       return path;
-
+    case 'react':
+      return React;
+    case 'react-dom/client':
+      return ReactDOM;
     default:
       throw new Error(`not found module ${module}`);
   }

--- a/packages/toolkit/webpack/config.build.js
+++ b/packages/toolkit/webpack/config.build.js
@@ -32,18 +32,6 @@ const libBundle = createWebpackConfig({
     },
     externals: [
       {
-        react: {
-          root: 'React',
-          commonjs2: 'react',
-          commonjs: 'react',
-          amd: 'react',
-        },
-        'react-dom': {
-          root: 'ReactDOM',
-          commonjs2: 'react-dom',
-          commonjs: 'react-dom',
-          amd: 'react-dom',
-        },
         moment: {
           root: 'moment',
           commonjs2: 'moment',
@@ -57,6 +45,9 @@ const libBundle = createWebpackConfig({
       minimize: false,
       concatenateModules: false,
       splitChunks: false,
+    },
+    experiments: {
+      asyncWebAssembly: true, // 启用 WebAssembly 支持
     },
   },
 });

--- a/packages/toolkit/webpack/config.build.js
+++ b/packages/toolkit/webpack/config.build.js
@@ -32,6 +32,62 @@ const libBundle = createWebpackConfig({
     },
     externals: [
       {
+        react: {
+          root: 'React',
+          commonjs2: 'react',
+          commonjs: 'react',
+          amd: 'react',
+        },
+        'react-dom': {
+          root: 'ReactDOM',
+          commonjs2: 'react-dom',
+          commonjs: 'react-dom',
+          amd: 'react-dom',
+        },
+        moment: {
+          root: 'moment',
+          commonjs2: 'moment',
+          commonjs: 'moment',
+          amd: 'moment',
+        },
+      },
+      '@codeblitzjs/ide-registry',
+    ],
+    optimization: {
+      minimize: false,
+      concatenateModules: false,
+      splitChunks: false,
+    },
+    experiments: {
+      asyncWebAssembly: true, // 启用 WebAssembly 支持
+    },
+  },
+});
+
+const libBundleWithReact = createWebpackConfig({
+  mode: 'production',
+  tsconfigPath: path.join(__dirname, '../../../tsconfig.json'),
+  outputPath: path.join(__dirname, '../../core/bundle'),
+  define: {
+    ...Object.keys(define).reduce((obj, key) => {
+      obj[key] = JSON.stringify(define[key]);
+      return obj;
+    }, {}),
+    __non_webpack_require__: '() => {}',
+  },
+  webpackConfig: {
+    context: path.join(__dirname, '../../..'),
+    entry: {
+      [config.appEntryWithReact]: './packages/core/src',
+    },
+    // 此处 bundle 的包仅作为 commonjs 使用，但因为 external 原因会导致 webpack4 加载 bundle 出错，因此还是使用 umd
+    output: {
+      library: 'AlexLib',
+      libraryTarget: 'umd',
+    },
+    externals: [
+      // 此处没有 external React，将 React 打包进去以应对 React16 的集成方
+      {
         moment: {
           root: 'moment',
           commonjs2: 'moment',
@@ -96,4 +152,4 @@ const globalBundle = createWebpackConfig({
   },
 });
 
-module.exports = [libBundle, globalBundle];
+module.exports = [libBundle, libBundleWithReact, globalBundle];

--- a/packages/toolkit/webpack/util/index.js
+++ b/packages/toolkit/webpack/util/index.js
@@ -33,6 +33,7 @@ exports.nodePolyfill = {
 
 exports.config = {
   appEntry: 'codeblitz',
+  appEntryWithReact: 'codeblitz-with-react',
   appGlobalEntry: 'codeblitz.global',
   appGlobalMinEntry: 'codeblitz.global.min',
   editorEntry: 'codeblitz.editor',

--- a/yarn.lock
+++ b/yarn.lock
@@ -738,8 +738,8 @@ __metadata:
     "@types/react-dom": "npm:^18.2.0"
     tslib: "npm:^2.2.0"
   peerDependencies:
-    react: ^18.2.0
-    react-dom: ^18.2.0
+    react: ^18.2.0 || ^16.0.0
+    react-dom: ^18.2.0 || ^16.0.0
   bin:
     codeblitz: bin/codeblitz
   languageName: unknown


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->


- [x] 🏗️ Build System


### Background or solution

fix #213 


example:

```tsx
// react 16
import React from 'react';
import ReactDOM from 'react-dom';

// from bundle
import { AppRenderer, requireModule } from '@codeblitzjs/ide-core/bundle/codeblitz-with-react';
// react-dom from bundle module
const ReactDom18 = requireModule('react-dom/client');


ReactDOM.render(<div style={{ position: 'fixed', top: 0, left: 0, background: 'red', zIndex: 1 }}>From React 16</div>, document.getElementById('main2'))
ReactDom18.createRoot(document.getElementById('main')).render(<App />);
```


![image](https://github.com/user-attachments/assets/9d88cc79-2a8c-4dd0-a158-b1c4afaa583f)


### ChangeLog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新特性**
	- 更新了构建配置，新增了支持 React 的库捆绑包配置，简化了构建过程。
	- 更新了 `@codeblitzjs/ide-core` 包的 `peerDependencies`，支持 React 16 和 18 的版本兼容性。
	- 增加了对 React 和 ReactDOM 的模块加载支持。
	- 扩展了应用程序入口点配置，新增 `appEntryWithReact` 属性。

- **优化**
	- 仅保留了库捆绑包的配置，提升了构建的效率和可维护性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->