### PR TITLE
fix: atomgit auth link missing '/'

### DIFF
--- a/packages/code-api/src/atomgit/atomgit.service.ts
+++ b/packages/code-api/src/atomgit/atomgit.service.ts
@@ -85,7 +85,7 @@ export class AtomGitAPIService implements ICodeAPIService {
       let popupWindow;
       if (btn === '去授权') {
         popupWindow = window.open(
-          `${this.config.origin}login/oauth/authorize?client_id=9d8b531661f441d1`,
+          `${this.config.origin}/login/oauth/authorize?client_id=9d8b531661f441d1`,
           '_blank',
           'directories=no,titlebar=no,toolbar=no,location=no,status=no,menubar=no,scrollbars=no,resizable=no,width=800,height=520,top=150,left=150',
         );


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->


- [x] 🐛 Bug Fixes

### Background or solution


### ChangeLog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- 修正了OAuth授权端点的URL结构，确保正确的访问令牌检查流程。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->