### PR TITLE
fix: use DOM ID to hide editor tab

### DIFF
--- a/packages/core/src/core/style.module.less
+++ b/packages/core/src/core/style.module.less
@@ -56,13 +56,8 @@ codeblitz-root {
 }
 
 .hide-editor-tab {
-  [class^='kt_editor_group'] {
-    > [class^='editorGroupHeader'] {
-      display: none !important;
-    }
-    > [class^='kt_editor_body'] {
-      height: 100% !important;
-    }
+  :global(#opensumi-editor-tabs) {
+    display: none;
   }
 }
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution


### ChangeLog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 更新了编辑器标签的可见性样式，直接控制标签的显示。
	- 调整了全局样式应用，确保样式在不同上下文中保持一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->